### PR TITLE
Resolve #14 - Add a custom Log class. Send info, warning and error logs to Firebase in order to include them when the app crashes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,31 @@ android {
     }
 
     productFlavors {
+
+        def BOOLEAN = "boolean"
+        def TRUE = "true"
+        def FALSE = "false"
+        def LOGE = "LOG_E"
+        def LOGW = "LOG_W"
+        def LOGI = "LOG_I"
+        def LOGD = "LOG_D"
+        def LOGV = "LOG_V"
+
         production {
+            buildConfigField BOOLEAN, LOGE, TRUE
+            buildConfigField BOOLEAN, LOGW, TRUE
+            buildConfigField BOOLEAN, LOGI, TRUE
+            buildConfigField BOOLEAN, LOGD, FALSE
+            buildConfigField BOOLEAN, LOGV, FALSE
         }
         development {
             applicationIdSuffix ".development"
             versionNameSuffix ".development"
+            buildConfigField BOOLEAN, LOGE, TRUE
+            buildConfigField BOOLEAN, LOGW, TRUE
+            buildConfigField BOOLEAN, LOGI, TRUE
+            buildConfigField BOOLEAN, LOGD, TRUE
+            buildConfigField BOOLEAN, LOGV, TRUE
         }
     }
 
@@ -33,13 +53,20 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
+
+    // General
     compile 'com.android.support:appcompat-v7:25.0.0'
     compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:support-annotations:25.0.0'
+    compile 'com.google.guava:guava:20.0'
+
+    // Firebase
     compile 'com.google.firebase:firebase-database:9.8.0'
     compile 'com.google.firebase:firebase-core:9.8.0'
     compile 'com.google.firebase:firebase-crash:9.8.0'
-    compile 'com.android.support:support-annotations:25.0.0'
-    compile 'com.google.guava:guava:20.0'
+
+    // Log utils
+    compile 'com.jakewharton.timber:timber:4.3.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.aguesoftguar.medalarm">
+    package="com.aguesoftguar.medalarm">
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
+        android:name=".main.MedAlarmApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -17,9 +18,9 @@
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/aguesoftguar/medalarm/main/MainActivity.java
+++ b/app/src/main/java/com/aguesoftguar/medalarm/main/MainActivity.java
@@ -27,6 +27,7 @@ import android.view.View;
 
 import com.aguesoftguar.medalarm.ActivityUtils;
 import com.aguesoftguar.medalarm.R;
+import com.aguesoftguar.medalarm.util.Log;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 /**
@@ -34,12 +35,16 @@ import com.google.firebase.analytics.FirebaseAnalytics;
  */
 public class MainActivity extends AppCompatActivity {
 
+   private static final String TAG = "MainActivity";
+
    private FirebaseAnalytics firebaseAnalytics;
 
    @Override
    protected void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
       setContentView(R.layout.activity_main);
+
+      Log.i(TAG, "Begin");
 
       // Firebase initialization
       firebaseAnalytics = FirebaseAnalytics.getInstance(this);
@@ -64,14 +69,20 @@ public class MainActivity extends AppCompatActivity {
          ActivityUtils.addFragmentToActivity(
             getSupportFragmentManager(), tasksFragment, R.id.contentFrame);
       }
+
+      Log.i(TAG, "Return");
    }
 
    @Override
    protected void onResume() {
       super.onResume();
 
+      Log.i(TAG, "Begin");
+
       // Send firebase open application event
       firebaseAnalytics.logEvent(FirebaseAnalytics.Event.APP_OPEN, new Bundle());
+
+      Log.i(TAG, "Return");
    }
 
    @Override

--- a/app/src/main/java/com/aguesoftguar/medalarm/main/MedAlarmApp.java
+++ b/app/src/main/java/com/aguesoftguar/medalarm/main/MedAlarmApp.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aguesoftguar.medalarm.main;
+
+import android.app.Application;
+import android.util.Log;
+
+import com.aguesoftguar.medalarm.BuildConfig;
+import com.google.firebase.crash.FirebaseCrash;
+
+import timber.log.Timber;
+
+/**
+ * {@link Application} used for the initial configuration.
+ */
+public class MedAlarmApp extends Application {
+
+   @Override
+   public void onCreate() {
+      super.onCreate();
+
+      Timber.uprootAll();
+
+      if (BuildConfig.DEBUG) {
+         Timber.plant(new Timber.DebugTree());
+      } else {
+         //TODO: 08/12/2016 Create a Timber tree for saving all the INFO, WARN and ERROR logs in
+         //a file
+         Timber.plant(new CrashReportingTree());
+      }
+   }
+
+   /**
+    * A tree which logs important information for crash reporting.
+    */
+   private static class CrashReportingTree extends Timber.Tree {
+      @Override
+      protected void log(int priority, String tag, String message, Throwable t) {
+         if (priority == Log.VERBOSE || priority == Log.DEBUG) {
+            return;
+         }
+
+         FirebaseCrash.logcat(priority, tag, message);
+
+         if (t != null) {
+            if (priority == Log.ERROR || priority == Log.WARN) {
+               FirebaseCrash.report(t);
+            }
+         }
+      }
+   }
+}

--- a/app/src/main/java/com/aguesoftguar/medalarm/util/Log.java
+++ b/app/src/main/java/com/aguesoftguar/medalarm/util/Log.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2016, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aguesoftguar.medalarm.util;
+
+import com.aguesoftguar.medalarm.BuildConfig;
+import com.google.firebase.crash.FirebaseCrash;
+
+import timber.log.Timber;
+
+/**
+ * This utility class is the main entrance to print log with Android Log class. Our application
+ * should always use this class to print logs.
+ */
+public class Log {
+
+   /**
+    * Tag used together with the log tag in order to identify quickly all the logs of the app
+    */
+   private static final String LOG_TAG = "MA_";
+
+   /**
+    * Basic log format using for android logcat: "[METHOD_NAME] LOG_MESSAGE"
+    */
+   private static final String LOG_MESSAGE_FORMAT = "[%s] %s";
+
+   /**
+    * Basic log format using for {@link FirebaseCrash}: "LOG_LEVEL/TAG: LOG MESSAGE" Exception
+    * message is logged if needed
+    */
+   private static final String FIREBASE_LOG_MESSAGE_FORMAT = "%s/%s: %s";
+
+   /**
+    * Variables used to know what log priority levels should be displayed
+    */
+   private static final boolean LOG_E = BuildConfig.LOG_E;
+   private static final boolean LOG_W = BuildConfig.LOG_W;
+   private static final boolean LOG_I = BuildConfig.LOG_I;
+   private static final boolean LOG_D = BuildConfig.LOG_D;
+   private static final boolean LOG_V = BuildConfig.LOG_V;
+
+   /**
+    * Send a {@link android.util.Log#VERBOSE} log message.
+    *
+    * @param tag     Used to identify the source of a log message. It usually identifies the class
+    *                or activity where the log call occurs.
+    * @param message The message to be logged.
+    */
+   public static void v(String tag, String message) {
+      if (LOG_V) {
+         printLog(android.util.Log.VERBOSE, tag, message, null);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#VERBOSE} log message and log the exception.
+    *
+    * @param tag       Used to identify the source of a log message. It usually identifies the
+    *                  class or activity where the log call occurs.
+    * @param message   The message to be logged.
+    * @param throwable An exception to log (can be null).
+    */
+   public static void v(String tag, String message, Throwable throwable) {
+      if (LOG_V) {
+         printLog(android.util.Log.VERBOSE, tag, message, throwable);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#DEBUG} log message.
+    *
+    * @param tag     Used to identify the source of a log message. It usually identifies the class
+    *                or activity where the log call occurs.
+    * @param message The message to be logged.
+    */
+   public static void d(String tag, String message) {
+      if (LOG_D) {
+         printLog(android.util.Log.DEBUG, tag, message, null);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#DEBUG} log message and log the exception.
+    *
+    * @param tag       Used to identify the source of a log message. It usually identifies the
+    *                  class or activity where the log call occurs.
+    * @param message   The message to be logged.
+    * @param throwable An exception to log (can be null).
+    */
+   public static void d(String tag, String message, Throwable throwable) {
+      if (LOG_D) {
+         printLog(android.util.Log.DEBUG, tag, message, throwable);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#INFO} log message.
+    *
+    * @param tag     Used to identify the source of a log message. It usually identifies the class
+    *                or activity where the log call occurs.
+    * @param message The message to be logged.
+    */
+   public static void i(String tag, String message) {
+      if (LOG_I) {
+         printLog(android.util.Log.INFO, tag, message, null);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#INFO} log message and log the exception.
+    *
+    * @param tag       Used to identify the source of a log message. It usually identifies the
+    *                  class or activity where the log call occurs.
+    * @param message   The message to be logged.
+    * @param throwable An exception to log (can be null).
+    */
+   public static void i(String tag, String message, Throwable throwable) {
+      if (LOG_I) {
+         printLog(android.util.Log.INFO, tag, message, throwable);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#WARN} log message.
+    *
+    * @param tag     Used to identify the source of a log message. It usually identifies the class
+    *                or activity where the log call occurs.
+    * @param message The message to be logged.
+    */
+   public static void w(String tag, String message) {
+      if (LOG_W) {
+         printLog(android.util.Log.WARN, tag, message, null);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#WARN} log message and log the exception.
+    *
+    * @param tag       Used to identify the source of a log message. It usually identifies the
+    *                  class or activity where the log call occurs.
+    * @param message   The message to be logged.
+    * @param throwable An exception to log (can be null).
+    */
+   public static void w(String tag, String message, Throwable throwable) {
+      if (LOG_W) {
+         printLog(android.util.Log.WARN, tag, message, throwable);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#ERROR} log message.
+    *
+    * @param tag     Used to identify the source of a log message. It usually identifies the class
+    *                or activity where the log call occurs.
+    * @param message The message to be logged.
+    */
+   public static void e(String tag, String message) {
+      if (LOG_E) {
+         printLog(android.util.Log.ERROR, tag, message, null);
+      }
+   }
+
+   /**
+    * Send a {@link android.util.Log#ERROR} log message and log the exception.
+    *
+    * @param tag       Used to identify the source of a log message. It usually identifies the
+    *                  class or activity where the log call occurs.
+    * @param message   The message to be logged.
+    * @param throwable An exception to log (can be null).
+    */
+   public static void e(String tag, String message, Throwable throwable) {
+      if (LOG_E) {
+         printLog(android.util.Log.ERROR, tag, message, throwable);
+      }
+   }
+
+   /**
+    * Print log in android logcat using {@link Timber} library and send the log message to the
+    * Firebase crash reporting tool.
+    *
+    * @param priority  Log priority, corresponding to {@link android.util.Log} priorities.
+    * @param tag       Class tag. Typically is the name of the class that emits the log.
+    * @param message   The message to be logged.
+    * @param throwable An exception to log (can be null).
+    * @see {@link FirebaseCrash}
+    */
+   private static void printLog(int priority, String tag, String message, Throwable throwable) {
+
+      //Build the log tag using the app tag (see TAG variable) and the class tag
+      String logTag = LOG_TAG + tag;
+
+      //Build the log message including the name of the method that calls Log method
+      String logMessage = String.format(LOG_MESSAGE_FORMAT, getMethodName(5), message);
+
+      //Only send custom logs to Firebase for error, warning and info messages
+      switch (priority) {
+         case android.util.Log.VERBOSE:
+            Timber.tag(logTag).v(throwable, logMessage);
+            break;
+         case android.util.Log.DEBUG:
+            Timber.tag(logTag).d(throwable, logMessage);
+            break;
+         case android.util.Log.INFO:
+            Timber.tag(logTag).i(throwable, logMessage);
+            FirebaseCrash.log(getCrashReporterLogMessage("I", logTag, logMessage, throwable));
+            break;
+         case android.util.Log.WARN:
+            Timber.tag(logTag).w(throwable, logMessage);
+            FirebaseCrash.log(getCrashReporterLogMessage("W", logTag, logMessage, throwable));
+            break;
+         case android.util.Log.ERROR:
+            Timber.tag(logTag).e(throwable, logMessage);
+            FirebaseCrash.log(getCrashReporterLogMessage("E", logTag, logMessage, throwable));
+            break;
+      }
+   }
+
+   /**
+    * Returns a {@link String} suitable for crash reporting tools
+    *
+    * @param priorityLevel Log level
+    * @param tag           Log tag
+    * @param msg           Log message
+    * @param throwable     Log exception (can be null)
+    * @return A {@link String} suitable for crash reporting
+    */
+   private static String getCrashReporterLogMessage(String priorityLevel, String tag, String msg, Throwable throwable) {
+      String logString = String.format(FIREBASE_LOG_MESSAGE_FORMAT, priorityLevel, tag, msg);
+      if (throwable != null) {
+         logString = String.format("%s\n%s", logString, getStackTraceString(throwable));
+      }
+      return logString;
+   }
+
+   /**
+    * Returns a stack trace string from a given {@link Throwable}
+    *
+    * @param throwable A {@link Throwable}
+    * @return the {@link Throwable}'s stack trace in string format
+    */
+   private static String getStackTraceString(Throwable throwable) {
+      return android.util.Log.getStackTraceString(throwable);
+   }
+
+   /**
+    * Util method that calls {@link Log#reportCrash(Throwable, String, String)} with the current
+    * method name.
+    *
+    * @param throwable Throwable object. It is usually an {@link Exception} object.
+    * @param tag       Log tag of the class that calls to this method.
+    */
+   public static void reportCrash(Throwable throwable, String tag) {
+      reportCrash(throwable, tag, getMethodName(throwable));
+   }
+
+   /**
+    * Util method used to report a exception in the camera execution. An error log is shown and an
+    * exception stack trace is printed.
+    *
+    * @param throwable  Throwable object. It is usually an {@link Exception} object.
+    * @param tag        Log tag of the class that calls to this method.
+    * @param methodName Name of the method that calls to this method.
+    */
+   private static void reportCrash(Throwable throwable, String tag, String methodName) {
+
+      if (methodName == null) {
+         methodName = getMethodName(throwable);
+      }
+
+      Log.e(tag, "[" + methodName + "] ERROR: " + throwable);
+      throwable.printStackTrace();
+      FirebaseCrash.report(throwable);
+   }
+
+   /**
+    * Get the name of the method that throws an exception using the {@link Throwable} stack trace.
+    *
+    * @param throwable Throwable object. It is usually an {@link Exception} object.
+    * @return Method name which throws the exception.
+    */
+   private static String getMethodName(Throwable throwable) {
+      StackTraceElement[] stacktrace = throwable.getStackTrace();
+      StackTraceElement stackTraceElement = stacktrace[0];
+      return stackTraceElement.getMethodName();
+   }
+
+   /**
+    * Get the method name for a depth in call stack.
+    *
+    * @param depth Depth in the call stack (0 means current method, 1 means call method, ...)
+    * @return Method name
+    */
+   private static String getMethodName(final int depth) {
+      final StackTraceElement[] ste = Thread.currentThread().getStackTrace();
+      return ste[depth].getMethodName();
+   }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:fitsSystemWindows="true"
@@ -18,16 +17,16 @@
             android:id="@+id/toolbar"
             android:layout_height="?attr/actionBarSize"
             android:layout_width="match_parent"
-            app:popupTheme="@style/AppTheme.PopupOverlay"/>
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
 
     </android.support.design.widget.AppBarLayout>
 
-    <include layout="@layout/content_main"/>
+    <include layout="@layout/content_main" />
 
     <FrameLayout
         android:id="@+id/contentFrame"
         android:layout_height="match_parent"
-        android:layout_width="match_parent"/>
+        android:layout_width="match_parent" />
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab"
@@ -35,6 +34,6 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/fab_margin"
         android:layout_width="wrap_content"
-        android:src="@android:drawable/ic_dialog_email"/>
+        android:src="@android:drawable/ic_dialog_email" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
@@ -16,5 +15,5 @@
     <TextView
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        android:text="Hello World!"/>
+        android:text="Hello World!" />
 </RelativeLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,10 +1,10 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context="com.aguesoftguar.medalarm.MainActivity">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="com.aguesoftguar.medalarm.MainActivity">
     <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"
         android:title="@string/action_settings"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,8 +13,8 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
 </resources>


### PR DESCRIPTION
A Log class has been added in order to manage all the app logs using Timber. All the logs are showed for "development" flavor but only error, warning and info logs are showed for "production" flavor.
Also, the error, warning al info logs are sent to Firebase to include them in the crashes reports.